### PR TITLE
Rack-like lambda integration

### DIFF
--- a/sentry-ruby/lib/sentry-ruby.rb
+++ b/sentry-ruby/lib/sentry-ruby.rb
@@ -19,6 +19,7 @@ require "sentry/background_worker"
 
 [
   "sentry/rake",
+  "sentry/lambda",
   "sentry/rack",
 ].each do |lib|
   begin

--- a/sentry-ruby/lib/sentry/event.rb
+++ b/sentry-ruby/lib/sentry/event.rb
@@ -28,7 +28,7 @@ module Sentry
 
       # Set some simple default values
       @event_id      = SecureRandom.uuid.delete("-")
-      @timestamp     = Sentry.utc_now.iso8601
+      @timestamp     = Sentry.utc_now.round(10).iso8601(6)
       @platform      = :ruby
       @sdk           = integration_meta || Sentry.sdk_meta
 

--- a/sentry-ruby/lib/sentry/lambda.rb
+++ b/sentry-ruby/lib/sentry/lambda.rb
@@ -2,7 +2,7 @@ require 'sentry/lambda/capture_exceptions'
 
 module Sentry
   module Lambda
-    def self.capture_exceptions(event:, context:, catpure_timeout_warning: false)
+    def self.wrap_handler(event:, context:, catpure_timeout_warning: false)
       CaptureExceptions.new(
         aws_event: event,
         aws_context: context,

--- a/sentry-ruby/lib/sentry/lambda.rb
+++ b/sentry-ruby/lib/sentry/lambda.rb
@@ -1,0 +1,11 @@
+require 'sentry/lambda/capture_exceptions'
+
+module Sentry
+  module Lambda
+    def self.capture_exceptions(event, context)
+      CaptureExceptions.new(event, context).call do
+        yield
+      end
+    end
+  end
+end

--- a/sentry-ruby/lib/sentry/lambda.rb
+++ b/sentry-ruby/lib/sentry/lambda.rb
@@ -2,8 +2,8 @@ require 'sentry/lambda/capture_exceptions'
 
 module Sentry
   module Lambda
-    def self.capture_exceptions(event, context)
-      CaptureExceptions.new(event, context).call do
+    def self.capture_exceptions(event, context, catpure_timeout_warning = false)
+      CaptureExceptions.new(event, context, catpure_timeout_warning).call do
         yield
       end
     end

--- a/sentry-ruby/lib/sentry/lambda.rb
+++ b/sentry-ruby/lib/sentry/lambda.rb
@@ -2,8 +2,12 @@ require 'sentry/lambda/capture_exceptions'
 
 module Sentry
   module Lambda
-    def self.capture_exceptions(event, context, catpure_timeout_warning = false)
-      CaptureExceptions.new(event, context, catpure_timeout_warning).call do
+    def self.capture_exceptions(event:, context:, catpure_timeout_warning: false)
+      CaptureExceptions.new(
+        aws_event: event,
+        aws_context: context,
+        catpure_timeout_warning: catpure_timeout_warning
+      ).call do
         yield
       end
     end

--- a/sentry-ruby/lib/sentry/lambda.rb
+++ b/sentry-ruby/lib/sentry/lambda.rb
@@ -2,11 +2,11 @@ require 'sentry/lambda/capture_exceptions'
 
 module Sentry
   module Lambda
-    def self.wrap_handler(event:, context:, catpure_timeout_warning: false)
+    def self.wrap_handler(event:, context:, capture_timeout_warning: false)
       CaptureExceptions.new(
         aws_event: event,
         aws_context: context,
-        catpure_timeout_warning: catpure_timeout_warning
+        capture_timeout_warning: capture_timeout_warning
       ).call do
         yield
       end

--- a/sentry-ruby/lib/sentry/lambda/capture_exceptions.rb
+++ b/sentry-ruby/lib/sentry/lambda/capture_exceptions.rb
@@ -103,7 +103,7 @@ module Sentry
         region = ENV['AWS_REGION']
 
         "https://console.aws.amazon.com/cloudwatch/home?region=#{region}" \
-        "#logEventViewer:group=#{aws_context.log_group};stream=#{aws_context.log_stream}" \
+        "#logEventViewer:group=#{aws_context.log_group_name};stream=#{aws_context.log_stream_name}" \
         ";start=#{start_time.strftime(formatstring)};end=#{(Time.now.utc + 2).strftime(formatstring)}"
       end
     end

--- a/sentry-ruby/lib/sentry/lambda/capture_exceptions.rb
+++ b/sentry-ruby/lib/sentry/lambda/capture_exceptions.rb
@@ -12,7 +12,7 @@ module Sentry
       def call(&block)
         return yield unless Sentry.initialized?
 
-        if @capture_timeout_warning
+        if @capture_timeout_warning && (@aws_context.get_remaining_time_in_millis > TIMEOUT_WARNING_BUFFER)
           Thread.new do
             configured_timeout_seconds = @aws_context.get_remaining_time_in_millis / 1000.0
             sleep_timeout_seconds = ((@aws_context.get_remaining_time_in_millis - TIMEOUT_WARNING_BUFFER) / 1000.0)

--- a/sentry-ruby/lib/sentry/lambda/capture_exceptions.rb
+++ b/sentry-ruby/lib/sentry/lambda/capture_exceptions.rb
@@ -25,7 +25,7 @@ module Sentry
 
           scope.add_event_processor do |event, hint|
             event_time = Time.parse(event.timestamp) rescue Time.now.utc
-            remaining_time_in_millis = execution_expiration_time - event_time
+            remaining_time_in_millis = ((event_time - execution_expiration_time) * 1000).round
             execution_duration_in_millis = ((event_time - start_time) * 1000).round
             event.extra = event.extra.merge(
               lambda: {

--- a/sentry-ruby/lib/sentry/lambda/capture_exceptions.rb
+++ b/sentry-ruby/lib/sentry/lambda/capture_exceptions.rb
@@ -30,11 +30,8 @@ module Sentry
 
         Sentry.with_scope do |scope|
           start_time = Time.now.utc
-          puts "start_time ::: #{start_time}"
           initial_remaining_time_in_milis = @aws_context.get_remaining_time_in_millis
-          puts "initial_remaining_time_in_milis ::: #{initial_remaining_time_in_milis}"
           execution_expiration_time = Time.now.utc + ((initial_remaining_time_in_milis || 0)/1000.0)
-          puts "execution_expiration_time ::: #{execution_expiration_time}"
 
           scope.clear_breadcrumbs
           scope.set_transaction_name(@aws_context.function_name)
@@ -80,8 +77,6 @@ module Sentry
           end
 
           finish_transaction(transaction, response[:statusCode])
-
-          timeout_thread&.kill
 
           response
         end

--- a/sentry-ruby/lib/sentry/lambda/capture_exceptions.rb
+++ b/sentry-ruby/lib/sentry/lambda/capture_exceptions.rb
@@ -76,7 +76,8 @@ module Sentry
             raise
           end
 
-          finish_transaction(transaction, response[:statusCode])
+          status_code = response&.dig(:statusCode) || response&.dig('statusCode')
+          finish_transaction(transaction, status_code)
 
           response
         end

--- a/sentry-ruby/lib/sentry/lambda/capture_exceptions.rb
+++ b/sentry-ruby/lib/sentry/lambda/capture_exceptions.rb
@@ -13,7 +13,7 @@ module Sentry
         return yield unless Sentry.initialized?
 
         if @catpure_timeout_warning
-          timeout_thread = Tread.new do
+          Thread.new do
             configured_time_out = @aws_context.get_remaining_time_in_millis / 1000.0
 
             timeout_message = "WARNING : Function is expected to get timed out. "\

--- a/sentry-ruby/lib/sentry/lambda/capture_exceptions.rb
+++ b/sentry-ruby/lib/sentry/lambda/capture_exceptions.rb
@@ -1,7 +1,7 @@
 module Sentry
   module Lambda
     class CaptureExceptions
-      TIMEOUT_WARNING_BUFFER = 1500  # Buffer time required to send timeout warning to Sentry
+      TIMEOUT_WARNING_BUFFER = 1500 # Buffer time required to send timeout warning to Sentry
 
       def initialize(aws_event:, aws_context:, capture_timeout_warning: false)
         @aws_event = aws_event

--- a/sentry-ruby/lib/sentry/lambda/capture_exceptions.rb
+++ b/sentry-ruby/lib/sentry/lambda/capture_exceptions.rb
@@ -14,8 +14,12 @@ module Sentry
 
         Sentry.with_scope do |scope|
           start_time = Time.now.utc
+          puts "start_time ::: #{start_time}"
           initial_remaining_time_in_milis = @aws_context.get_remaining_time_in_millis
-          execution_expiration_time = Time.now.utc + (@aws_context&.get_remaining_time_in_millis || 0)
+          puts "initial_remaining_time_in_milis ::: #{initial_remaining_time_in_milis}"
+          execution_expiration_time = Time.now.utc + (initial_remaining_time_in_milis || 0)
+          puts "execution_expiration_time ::: #{execution_expiration_time}"
+
           scope.clear_breadcrumbs
           scope.set_transaction_name(@aws_context.function_name)
 

--- a/sentry-ruby/lib/sentry/lambda/capture_exceptions.rb
+++ b/sentry-ruby/lib/sentry/lambda/capture_exceptions.rb
@@ -17,7 +17,7 @@ module Sentry
           puts "start_time ::: #{start_time}"
           initial_remaining_time_in_milis = @aws_context.get_remaining_time_in_millis
           puts "initial_remaining_time_in_milis ::: #{initial_remaining_time_in_milis}"
-          execution_expiration_time = Time.now.utc + (initial_remaining_time_in_milis || 0)
+          execution_expiration_time = Time.now.utc + ((initial_remaining_time_in_milis || 0)/1000)
           puts "execution_expiration_time ::: #{execution_expiration_time}"
 
           scope.clear_breadcrumbs

--- a/sentry-ruby/lib/sentry/lambda/capture_exceptions.rb
+++ b/sentry-ruby/lib/sentry/lambda/capture_exceptions.rb
@@ -38,6 +38,14 @@ module Sentry
               }
             )
 
+            event.extra = event.extra.merge(
+              "cloudwatch logs": {
+                url: _get_cloudwatch_logs_url(@aws_context, start_time),
+                log_group: @aws_context.log_group_name,
+                log_stream: @aws_context.log_stream_name
+              }
+            )
+
             event
           end
 
@@ -88,6 +96,15 @@ module Sentry
 
       def capture_exception(exception)
         Sentry.capture_exception(exception)
+      end
+
+      def _get_cloudwatch_logs_url(aws_context, start_time)
+        formatstring = "%Y-%m-%dT%H:%M:%SZ"
+        region = ENV['AWS_REGION']
+
+        "https://console.aws.amazon.com/cloudwatch/home?region=#{region}" \
+        "#logEventViewer:group=#{aws_context.log_group};stream=#{aws_context.log_stream}" \
+        ";start=#{start_time.strftime(formatstring)};end=#{end_time.strftime(formatstring)}"
       end
     end
   end

--- a/sentry-ruby/lib/sentry/lambda/capture_exceptions.rb
+++ b/sentry-ruby/lib/sentry/lambda/capture_exceptions.rb
@@ -104,7 +104,7 @@ module Sentry
 
         "https://console.aws.amazon.com/cloudwatch/home?region=#{region}" \
         "#logEventViewer:group=#{aws_context.log_group};stream=#{aws_context.log_stream}" \
-        ";start=#{start_time.strftime(formatstring)};end=#{end_time.strftime(formatstring)}"
+        ";start=#{start_time.strftime(formatstring)};end=#{(Time.now.utc + 2).strftime(formatstring)}"
       end
     end
   end

--- a/sentry-ruby/lib/sentry/lambda/capture_exceptions.rb
+++ b/sentry-ruby/lib/sentry/lambda/capture_exceptions.rb
@@ -14,12 +14,13 @@ module Sentry
 
         if @catpure_timeout_warning
           Thread.new do
-            configured_time_out = @aws_context.get_remaining_time_in_millis / 1000.0
+            configured_timeout_seconds = @aws_context.get_remaining_time_in_millis / 1000.0
+            sleep_timeout_seconds = ((@aws_context.get_remaining_time_in_millis - TIMEOUT_WARNING_BUFFER) / 1000.0)
 
             timeout_message = "WARNING : Function is expected to get timed out. "\
-                              "Configured timeout duration = #{configured_time_out.round} seconds."
+                              "Configured timeout duration = #{configured_timeout_seconds.round} seconds."
 
-            sleep(configured_time_out - TIMEOUT_WARNING_BUFFER)
+            sleep(sleep_timeout_seconds)
             Sentry.capture_message(timeout_message)
           end
         end

--- a/sentry-ruby/lib/sentry/lambda/capture_exceptions.rb
+++ b/sentry-ruby/lib/sentry/lambda/capture_exceptions.rb
@@ -1,0 +1,70 @@
+module Sentry
+  module Lambda
+    class CaptureExceptions
+      def initialize(event, context)
+        @event = event
+        @context = context
+      end
+
+      def call(&block)
+        return yield unless Sentry.initialized?
+
+        # make sure the current thread has a clean hub
+        Sentry.clone_hub_to_current_thread
+
+        Sentry.with_scope do |scope|
+          scope.clear_breadcrumbs
+          scope.set_transaction_name(@context.function_name)
+          # TODO: sometning like - `scope.set_rack_env(env)`
+
+          transaction = start_transaction(@event, @context, scope.transaction_name)
+          scope.set_span(transaction) if transaction
+
+          begin
+            response = yield
+          rescue Sentry::Error
+            finish_transaction(transaction, 500)
+            raise # Don't capture Sentry errors
+          rescue Exception => e
+            capture_exception(e)
+            finish_transaction(transaction, 500)
+            raise
+          end
+
+          finish_transaction(transaction, response[:statusCode])
+
+          response
+        end
+      end
+
+      def start_transaction(event, context, transaction_name)
+        Sentry.start_transaction(
+          transaction: nil,
+          custom_sampling_context: {
+            aws_event: event,
+            aws_context: context
+          },
+          name: transaction_name, op: 'serverless.function'
+        )
+      end
+
+      def start_transaction(event, context, transaction_name)
+        sentry_trace = event["HTTP_SENTRY_TRACE"]
+        options = { name: transaction_name, op: 'serverless.function' }
+        transaction = Sentry::Transaction.from_sentry_trace(sentry_trace, **options) if sentry_trace
+        Sentry.start_transaction(transaction: transaction, **options)
+      end
+
+      def finish_transaction(transaction, status_code)
+        return unless transaction
+
+        transaction.set_http_status(status_code)
+        transaction.finish
+      end
+
+      def capture_exception(exception)
+        Sentry.capture_exception(exception)
+      end
+    end
+  end
+end

--- a/sentry-ruby/lib/sentry/lambda/capture_exceptions.rb
+++ b/sentry-ruby/lib/sentry/lambda/capture_exceptions.rb
@@ -3,16 +3,16 @@ module Sentry
     class CaptureExceptions
       TIMEOUT_WARNING_BUFFER = 1500  # Buffer time required to send timeout warning to Sentry
 
-      def initialize(aws_event:, aws_context:, catpure_timeout_warning: false)
+      def initialize(aws_event:, aws_context:, capture_timeout_warning: false)
         @aws_event = aws_event
         @aws_context = aws_context
-        @catpure_timeout_warning = catpure_timeout_warning
+        @capture_timeout_warning = capture_timeout_warning
       end
 
       def call(&block)
         return yield unless Sentry.initialized?
 
-        if @catpure_timeout_warning
+        if @capture_timeout_warning
           Thread.new do
             configured_timeout_seconds = @aws_context.get_remaining_time_in_millis / 1000.0
             sleep_timeout_seconds = ((@aws_context.get_remaining_time_in_millis - TIMEOUT_WARNING_BUFFER) / 1000.0)

--- a/sentry-ruby/lib/sentry/lambda/capture_exceptions.rb
+++ b/sentry-ruby/lib/sentry/lambda/capture_exceptions.rb
@@ -25,7 +25,7 @@ module Sentry
 
           scope.add_event_processor do |event, hint|
             event_time = Time.parse(event.timestamp) rescue Time.now.utc
-            remaining_time_in_millis = ((event_time - execution_expiration_time) * 1000).round
+            remaining_time_in_millis = ((execution_expiration_time - event_time) * 1000).round
             execution_duration_in_millis = ((event_time - start_time) * 1000).round
             event.extra = event.extra.merge(
               lambda: {

--- a/sentry-ruby/lib/sentry/lambda/capture_exceptions.rb
+++ b/sentry-ruby/lib/sentry/lambda/capture_exceptions.rb
@@ -83,17 +83,6 @@ module Sentry
       end
 
       def start_transaction(event, context, transaction_name)
-        Sentry.start_transaction(
-          transaction: nil,
-          custom_sampling_context: {
-            aws_event: event,
-            aws_context: context
-          },
-          name: transaction_name, op: 'serverless.function'
-        )
-      end
-
-      def start_transaction(event, context, transaction_name)
         sentry_trace = event["HTTP_SENTRY_TRACE"]
         options = { name: transaction_name, op: 'serverless.function' }
         transaction = Sentry::Transaction.from_sentry_trace(sentry_trace, **options) if sentry_trace

--- a/sentry-ruby/lib/sentry/lambda/capture_exceptions.rb
+++ b/sentry-ruby/lib/sentry/lambda/capture_exceptions.rb
@@ -17,7 +17,7 @@ module Sentry
           puts "start_time ::: #{start_time}"
           initial_remaining_time_in_milis = @aws_context.get_remaining_time_in_millis
           puts "initial_remaining_time_in_milis ::: #{initial_remaining_time_in_milis}"
-          execution_expiration_time = Time.now.utc + ((initial_remaining_time_in_milis || 0)/1000)
+          execution_expiration_time = Time.now.utc + ((initial_remaining_time_in_milis || 0)/1000.0)
           puts "execution_expiration_time ::: #{execution_expiration_time}"
 
           scope.clear_breadcrumbs

--- a/sentry-ruby/lib/sentry/lambda/capture_exceptions.rb
+++ b/sentry-ruby/lib/sentry/lambda/capture_exceptions.rb
@@ -37,7 +37,7 @@ module Sentry
           scope.set_transaction_name(@aws_context.function_name)
 
           scope.add_event_processor do |event, hint|
-            event_time = Time.parse(event.timestamp) rescue Time.now.utc
+            event_time = event.timestamp.is_a?(Float) ? Time.at(event.timestamp) : Time.parse(event.timestamp)
             remaining_time_in_millis = ((execution_expiration_time - event_time) * 1000).round
             execution_duration_in_millis = ((event_time - start_time) * 1000).round
             event.extra = event.extra.merge(

--- a/sentry-ruby/lib/sentry/lambda/capture_exceptions.rb
+++ b/sentry-ruby/lib/sentry/lambda/capture_exceptions.rb
@@ -3,7 +3,7 @@ module Sentry
     class CaptureExceptions
       TIMEOUT_WARNING_BUFFER = 1500  # Buffer time required to send timeout warning to Sentry
 
-      def initialize(aws_event, aws_context, catpure_timeout_warning = false)
+      def initialize(aws_event:, aws_context:, catpure_timeout_warning: false)
         @aws_event = aws_event
         @aws_context = aws_context
         @catpure_timeout_warning = catpure_timeout_warning

--- a/sentry-ruby/spec/sentry/lambda/capture_exceptions_spec.rb
+++ b/sentry-ruby/spec/sentry/lambda/capture_exceptions_spec.rb
@@ -46,13 +46,9 @@ RSpec.describe Sentry::Lambda::CaptureExceptions do
     end
 
     it 'captures the exception from direct raise' do
-      stack = described_class.new(aws_event: aws_event, aws_context: aws_context)
+       wrapped_handler = described_class.new(aws_event: aws_event, aws_context: aws_context)
 
-      expect do
-        stack.call do
-          raise exception
-        end
-      end.to raise_error(ZeroDivisionError)
+      expect { wrapped_handler.call { raise exception } }.to raise_error(ZeroDivisionError)
 
       event = transport.events.last
       expect(event).to be_truthy
@@ -71,9 +67,9 @@ RSpec.describe Sentry::Lambda::CaptureExceptions do
       it 'sets the transaction and captures extras' do
         Timecop.freeze(now)
 
-        stack = described_class.new(aws_event: aws_event, aws_context: aws_context)
+         wrapped_handler = described_class.new(aws_event: aws_event, aws_context: aws_context)
 
-        stack.call do
+         wrapped_handler.call do
           Timecop.freeze(now + 3)
           Sentry.capture_message('test')
           happy_response
@@ -113,9 +109,9 @@ RSpec.describe Sentry::Lambda::CaptureExceptions do
         now = Time.now
         Timecop.freeze(now)
 
-        stack = described_class.new(aws_event: aws_event, aws_context: aws_context, capture_timeout_warning: true)
+         wrapped_handler = described_class.new(aws_event: aws_event, aws_context: aws_context, capture_timeout_warning: true)
 
-        stack.call do
+         wrapped_handler.call do
           sleep 2
 
           happy_response
@@ -133,10 +129,8 @@ RSpec.describe Sentry::Lambda::CaptureExceptions do
     end
 
     it 'returns happy result' do
-      stack = described_class.new(aws_event: aws_event, aws_context: aws_context)
-      expect do
-        stack.call { happy_response }
-      end.to_not raise_error
+       wrapped_handler = described_class.new(aws_event: aws_event, aws_context: aws_context)
+      expect { wrapped_handler.call { happy_response } }.to_not raise_error
     end
 
     describe "state encapsulation" do

--- a/sentry-ruby/spec/sentry/lambda/capture_exceptions_spec.rb
+++ b/sentry-ruby/spec/sentry/lambda/capture_exceptions_spec.rb
@@ -46,7 +46,6 @@ RSpec.describe Sentry::Lambda::CaptureExceptions do
     end
 
     it 'captures the exception from direct raise' do
-      app = ->(_e) { raise exception }
       stack = described_class.new(aws_event: aws_event, aws_context: aws_context)
 
       expect do
@@ -56,7 +55,8 @@ RSpec.describe Sentry::Lambda::CaptureExceptions do
       end.to raise_error(ZeroDivisionError)
 
       event = transport.events.last
-      # TODO: event does not have request
+      expect(event).to be_truthy
+      # TODO: event does not have request - handle aws_event request data
       # expect(event.to_hash.dig(:request, :url)).to eq("http://example.org/test")
     end
 

--- a/sentry-ruby/spec/sentry/lambda/capture_exceptions_spec.rb
+++ b/sentry-ruby/spec/sentry/lambda/capture_exceptions_spec.rb
@@ -32,7 +32,7 @@ RSpec.describe Sentry::Lambda::CaptureExceptions do
     end
 
     it "allows for shorthand syntax" do
-      response = Sentry::Lambda.capture_exceptions(event: aws_event, context: aws_context) do
+      response = Sentry::Lambda.wrap_handler(event: aws_event, context: aws_context) do
         happy_response
       end
 

--- a/sentry-ruby/spec/sentry/lambda/capture_exceptions_spec.rb
+++ b/sentry-ruby/spec/sentry/lambda/capture_exceptions_spec.rb
@@ -102,6 +102,26 @@ RSpec.describe Sentry::Lambda::CaptureExceptions do
       end
     end
 
+    context 'capture_timeout_warning' do
+      let(:aws_context_remaining_time) { 1500 } #
+
+      it 'captures a warning message' do
+        now = Time.now
+        Timecop.freeze(now)
+
+        stack = described_class.new(aws_event: aws_event, aws_context: aws_context, capture_timeout_warning: true)
+
+        stack.call do
+          sleep 1
+
+          happy_response
+        end
+
+        event = transport.events.last
+        expect(event.message).to eq 'WARNING : Function is expected to get timed out. Configured timeout duration = 2 seconds.'
+      end
+    end
+
     it 'returns happy result' do
       stack = described_class.new(aws_event: aws_event, aws_context: aws_context)
       expect do

--- a/sentry-ruby/spec/sentry/lambda/capture_exceptions_spec.rb
+++ b/sentry-ruby/spec/sentry/lambda/capture_exceptions_spec.rb
@@ -103,7 +103,11 @@ RSpec.describe Sentry::Lambda::CaptureExceptions do
     end
 
     context 'capture_timeout_warning' do
-      let(:aws_context_remaining_time) { 1500 } #
+      after do
+        Timecop.return
+      end
+
+      let(:aws_context_remaining_time) { 1501 } #
 
       it 'captures a warning message' do
         now = Time.now
@@ -112,7 +116,7 @@ RSpec.describe Sentry::Lambda::CaptureExceptions do
         stack = described_class.new(aws_event: aws_event, aws_context: aws_context, capture_timeout_warning: true)
 
         stack.call do
-          sleep 1
+          sleep 2
 
           happy_response
         end

--- a/sentry-ruby/spec/sentry/lambda/capture_exceptions_spec.rb
+++ b/sentry-ruby/spec/sentry/lambda/capture_exceptions_spec.rb
@@ -122,6 +122,12 @@ RSpec.describe Sentry::Lambda::CaptureExceptions do
       end
     end
 
+    context "handler does not return a hash response" do
+      it 'does not raise an error' do
+        expect { described_class.new(aws_event: aws_event, aws_context: aws_context).call {} }.not_to raise_error
+      end
+    end
+
     it 'returns happy result' do
       stack = described_class.new(aws_event: aws_event, aws_context: aws_context)
       expect do

--- a/sentry-ruby/spec/sentry/lambda/capture_exceptions_spec.rb
+++ b/sentry-ruby/spec/sentry/lambda/capture_exceptions_spec.rb
@@ -1,0 +1,242 @@
+require 'spec_helper'
+require 'pry'
+
+RSpec.describe Sentry::Lambda::CaptureExceptions do
+  let(:exception) { ZeroDivisionError.new("divided by 0") }
+  let(:additional_headers) { {} }
+  let(:aws_event) do
+    {}
+  end
+  let(:aws_context) do
+    OpenStruct.new(
+      function_name: 'my-function'
+    )
+  end
+  let(:happy_response) do
+    {
+      statusCode: 200,
+      body: {
+        success: true,
+        message: 'happy'
+      }.to_json
+    }
+  end
+
+  let(:transport) do
+    Sentry.get_current_client.transport
+  end
+
+  describe "exceptions capturing" do
+    before do
+      perform_basic_setup
+    end
+
+    it "allows for shorthand syntax" do
+      response = Sentry::Lambda.capture_exceptions(aws_event, aws_context) do
+        happy_response
+      end
+
+      expect(response).to eq(happy_response)
+    end
+
+    it 'captures the exception from direct raise' do
+      app = ->(_e) { raise exception }
+      stack = described_class.new(aws_event, aws_context)
+
+      expect do
+        stack.call do
+          raise exception
+        end
+      end.to raise_error(ZeroDivisionError)
+
+      event = transport.events.last
+      # TODO: event does not have request
+      # expect(event.to_hash.dig(:request, :url)).to eq("http://example.org/test")
+    end
+
+    xit 'sets the transaction and something like rack env' do
+      app = lambda do |e|
+        e['rack.exception'] = exception
+        [200, {}, ['okay']]
+      end
+      stack = described_class.new(app)
+
+      stack.call(env)
+
+      event = transport.events.last
+      expect(event.transaction).to eq("/test")
+      # expect(event.to_hash.dig(:request, :url)).to eq("http://example.org/test")
+      expect(Sentry.get_current_scope.transaction_names).to be_empty
+      expect(Sentry.get_current_scope.rack_env).to eq({})
+    end
+
+    it 'returns happy result' do
+      stack = described_class.new(aws_event, aws_context)
+      expect do
+        stack.call { happy_response }
+      end.to_not raise_error
+    end
+
+    describe "state encapsulation" do
+      before do
+        Sentry.configure_scope { |s| s.set_tags(tag_1: "don't change me") }
+      end
+
+      it "only contains the breadcrumbs of the request" do
+        logger = ::Logger.new(nil)
+
+        logger.info("old breadcrumb")
+
+        app_1 = described_class.new(aws_event, aws_context)
+
+        app_1.call do
+          logger.info("request breadcrumb")
+          Sentry.capture_message("test")
+          happy_response
+        end
+
+        event = transport.events.last
+        expect(event.breadcrumbs.count).to eq(1)
+        expect(event.breadcrumbs.peek.message).to eq("request breadcrumb")
+      end
+      it "doesn't pollute the top-level scope" do
+        app_1 = described_class.new(aws_event, aws_context)
+
+        app_1.call do
+          Sentry.configure_scope { |s| s.set_tags({tag_1: "foo"}) }
+          Sentry.capture_message("test")
+          happy_response
+        end
+
+        event = transport.events.last
+        expect(event.tags).to eq(tag_1: "foo")
+        expect(Sentry.get_current_scope.tags).to eq(tag_1: "don't change me")
+      end
+      it "doesn't pollute other request's scope" do
+        app_1 = described_class.new(aws_event, aws_context)
+        app_1.call do
+          Sentry.configure_scope { |s| s.set_tags({tag_1: "foo"}) }
+          Sentry.capture_message('capture me')
+          happy_response
+        end
+
+        event = transport.events.last
+        expect(event.tags).to eq(tag_1: "foo")
+        expect(Sentry.get_current_scope.tags).to eq(tag_1: "don't change me")
+
+        app_2 = described_class.new(aws_event, aws_context)
+
+        app_2.call do
+          Sentry.configure_scope { |s| s.set_tags({tag_2: "bar"}) }
+          Sentry.capture_message('capture me 2')
+          happy_response
+        end
+
+        event = transport.events.last
+        expect(event.tags).to eq(tag_2: "bar", tag_1: "don't change me")
+        expect(Sentry.get_current_scope.tags).to eq(tag_1: "don't change me")
+      end
+    end
+  end
+
+  describe "performance monitoring" do
+    before do
+      perform_basic_setup do |config|
+        config.traces_sample_rate = 0.5
+      end
+    end
+
+    context "when the transaction is sampled" do
+      before do
+        allow(Random).to receive(:rand).and_return(0.4)
+      end
+
+      it "starts a span and finishes it" do
+        described_class.new(aws_event, aws_context).call do
+          happy_response
+        end
+
+        transaction = transport.events.last
+        expect(transaction.type).to eq("transaction")
+        expect(transaction.timestamp).not_to be_nil
+        expect(transaction.contexts.dig(:trace, :status)).to eq("ok")
+        expect(transaction.contexts.dig(:trace, :op)).to eq("serverless.function")
+        expect(transaction.spans.count).to eq(0)
+      end
+    end
+
+    context "when the transaction is not sampled" do
+      before do
+        allow(Random).to receive(:rand).and_return(0.6)
+      end
+
+      it "doesn't do anything" do
+        described_class.new(aws_event, aws_context) do
+          happy_response
+        end
+
+        expect(transport.events.count).to eq(0)
+      end
+    end
+
+    context "when there's an exception" do
+      before do
+        allow(Random).to receive(:rand).and_return(0.4)
+      end
+
+      it "still finishes the transaction" do
+        expect do
+          described_class.new(aws_event, aws_context).call do
+            raise 'foo'
+          end
+        end.to raise_error("foo")
+
+        expect(transport.events.count).to eq(2)
+        event = transport.events.first
+        transaction = transport.events.last
+        expect(event.contexts.dig(:trace, :trace_id).length).to eq(32)
+        expect(event.contexts.dig(:trace, :trace_id)).to eq(transaction.contexts.dig(:trace, :trace_id))
+
+
+        expect(transaction.type).to eq("transaction")
+        expect(transaction.timestamp).not_to be_nil
+        expect(transaction.contexts.dig(:trace, :status)).to eq("internal_error")
+        expect(transaction.contexts.dig(:trace, :op)).to eq("serverless.function")
+        expect(transaction.spans.count).to eq(0)
+      end
+    end
+
+    context "when traces_sample_rate is not set" do
+      before do
+        Sentry.configuration.traces_sample_rate = nil
+      end
+
+      it "doesn't record transaction" do
+        described_class.new(aws_event, aws_context) { happy_response }
+
+        expect(transport.events.count).to eq(0)
+      end
+
+      context "when sentry-trace header is sent" do
+        let(:external_transaction) do
+          Sentry::Transaction.new(
+            op: "pageload",
+            status: "ok",
+            sampled: true,
+            name: "a/path",
+            hub: Sentry.get_current_hub
+          )
+        end
+
+        let(:aws_event) { { 'HTTP_SENTRY_TRACE' => external_transaction.to_sentry_trace } }
+
+        it "doesn't cause the transaction to be recorded" do
+          response = described_class.new(aws_event, aws_context).call { happy_response }
+
+          expect(response[:statusCode]).to eq(200)
+          expect(transport.events).to be_empty
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
## Description
Adds Lambda support for ruby lambda functions, using syntax like so:
```
def lambda_handler(event:, context:)
  Sentry::Lambda.wrap_handler(event: event, context: context) do
    # custom biz logic goes here
  end
end
```

Note that while this may give us the sentry support which we need for now, the intent is to also submit this public change set as a PR to getsentry repo, once we have captured any feedback from the team. That way we can iterate on our own implementation while also (hopefully) gathering feedback from the sentry-ruby team.

This implementation was largely based off of the [Rack integration](https://github.com/paymentspring/sentry-ruby/blob/master/sentry-ruby/lib/sentry/rack/capture_exceptions.rb). From there I attempted to capture sentry info similar to how the [python integration](https://github.com/getsentry/sentry-python/blob/master/sentry_sdk/integrations/aws_lambda.py) does.

The python example raises a [Timeout Warning](https://docs.sentry.io/platforms/python/guides/aws-lambda/#timeout-warning), whereas I decided to capture a sentry message and allow the function to continue.

I have not yet captured information about the [request/requestor](https://github.com/getsentry/sentry-python/blob/master/sentry_sdk/integrations/aws_lambda.py#L333-L369). There is information that could be pulled from the aws event hash, but we've decided to defer implementation for now.
