### PR TITLE
Annotate problems with timeout warning

### DIFF
--- a/sentry-lambda/README.md
+++ b/sentry-lambda/README.md
@@ -45,6 +45,7 @@ def lambda_handler(event:, context:)
   end
 end
 ```
+We experience issue that when function invocation was terminated after 2 seconds, we get warning about timeout. Seems it does not work well. 
 
 ### Integration Specific Configuration
 


### PR DESCRIPTION
Guys, can you open issue tracker ?

There is no other way to discuss things, report errors or propose some solutions than PRs.

BTW
This gem works great : )